### PR TITLE
feat: Background Task Management

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,13 +6,56 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:provider/provider.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:steps_tracker/firebase_options.dart';
-import 'package:steps_tracker/screens/auth_screen.dart';
 import 'package:steps_tracker/state/steps_tracker_cubit.dart';
 import 'package:steps_tracker/tabs/home_page_tab.dart';
 import 'package:steps_tracker/screens/new_user_screen.dart';
+import 'package:workmanager/workmanager.dart';
+
+// This function is called periodically by Workmanager
+@pragma('vm:entry-point')
+Future<void> callbackDispatcher()async {
+  Workmanager().executeTask((taskName, inputData) async {
+    // Ensure Flutter bindings are initialized (for background execution)
+    WidgetsFlutterBinding.ensureInitialized();
+
+    final prefs = await SharedPreferences.getInstance();
+
+    // Read the saved baseline (the step count at the start of the day)
+    final int baseline = prefs.getInt('baselineSteps') ?? 0;
+    // Read the current step count (this value should be updated by your active app logic)
+    final int currentCount = prefs.getInt('currentSteps') ?? 0;
+
+    // Compute the daily steps
+    final int dailySteps = currentCount - baseline;
+    prefs.setInt('dailySteps', dailySteps);
+    log('Background task: dailySteps = $dailySteps');
+
+    // Check if the day has changed (you can also store the date of the baseline)
+    final String storedDate = prefs.getString('baselineDate') ?? '';
+    final String today = DateTime.now().toIso8601String().substring(0, 10);
+    if (storedDate != today) {
+      // It’s a new day – reset the baseline to the current count and update the stored date
+      prefs.setInt('baselineSteps', currentCount);
+      prefs.setString('baselineDate', today);
+      log('New day detected. Baseline reset to $currentCount for $today');
+    }
+
+    // Return true to indicate successful completion.
+    return await Future.value(true);
+  });
+}
 
 void main() async {
   WidgetsFlutterBinding.ensureInitialized();
+
+  // Initialize Workmanager and schedule the periodic task.
+  Workmanager().initialize(callbackDispatcher, isInDebugMode: true);
+  Workmanager().registerPeriodicTask(
+    "dailyStepCountTask",
+    "updateDailySteps",
+    frequency: const Duration(minutes: 15), // adjust as needed
+  );
+  
   SharedPreferences prefs = await SharedPreferences.getInstance();
   bool isNew = prefs.getBool('isNew') ?? true;
   if (isNew) {
@@ -28,14 +71,13 @@ void main() async {
 
   runApp(
     MultiProvider(
-        providers: [
-          BlocProvider(create: (_) => StepTrackerCubit()),
-        ],
-        child: MaterialApp(
-          home: isNew ? NewUserScreen() : HomeScreen(),
-          debugShowCheckedModeBanner: false,
-        )
-        // : App(),
-        ),
+      providers: [
+        BlocProvider(create: (_) => StepTrackerCubit()),
+      ],
+      child: MaterialApp(
+        home: isNew ? NewUserScreen() : HomeScreen(),
+        debugShowCheckedModeBanner: false,
+      ),
+    ),
   );
 }

--- a/lib/state/steps_tracker_cubit.dart
+++ b/lib/state/steps_tracker_cubit.dart
@@ -4,46 +4,34 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:steps_tracker/models/step_tracker_model.dart';
 import 'package:steps_tracker/services/permission_service.dart';
-import 'package:workmanager/workmanager.dart';
 
 class StepTrackerCubit extends Cubit<int> {
   final StepTrackerModel _stepTrackerModel = StepTrackerModel();
 
   StepTrackerCubit() : super(0) {
     _initialize();
-    _startBackgroundSync();
   }
 
   void _initialize() async {
+    // Retrieve saved steps from persistent storage.
+    final prefs = await SharedPreferences.getInstance();
+    final savedSteps = prefs.getInt('savedSteps') ?? 0;
+    emit(savedSteps); // Emit the persisted count as the initial state.
+
     final hasPermission = await PermissionsService.requestStepPermissions();
     if (hasPermission) {
       log('Permission granted');
       await _stepTrackerModel.initialize();
       _stepTrackerModel.stepCountStream.listen((event) {
-        emit(event); // Emit the current step count
-        log('Steps updated: $event');
-        _saveSteps(event); // Save steps to storage for persistence
+        if (event > savedSteps) {
+          emit(event);
+          log('Steps updated: $event');
+          _saveSteps(event);
+        } // Save steps to storage for persistence.
       });
     } else {
       log('Permission denied');
     }
-  }
-
-  void _startBackgroundSync() {
-    Workmanager().initialize(callbackDispatcher);
-    Workmanager().registerPeriodicTask(
-      "syncSteps",
-      "stepBackgroundTask",
-      frequency: const Duration(minutes: 15),
-    );
-  }
-
-  static void callbackDispatcher() {
-    Workmanager().executeTask((taskName, inputData) async {
-      log('Background task running');
-      //TODO: Fetch steps here using platform API (e.g., Google Fit or CMPedometer)
-      return Future.value(true);
-    });
   }
 
   void reset() {
@@ -52,8 +40,41 @@ class StepTrackerCubit extends Cubit<int> {
     log('Steps reset');
   }
 
+  /// Persists the current step count and updates daily step tracking.
+  ///
+  /// This method:
+  /// - Stores the current step count as 'currentSteps'.
+  /// - Checks if today's date matches the stored baseline date.
+  ///   - If not, it resets the baseline (stored as 'baselineSteps') and sets 'dailySteps' to 0.
+  ///   - Otherwise, it computes daily steps by subtracting the baseline from the current count.
+  /// - Also stores the overall count under 'savedSteps' (for backward compatibility if needed).
   Future<void> _saveSteps(int steps) async {
     final prefs = await SharedPreferences.getInstance();
+
+    // Save the current step count.
+    prefs.setInt('currentSteps', steps);
+
+    // Get today's date in YYYY-MM-DD format.
+    final today = DateTime.now().toIso8601String().substring(0, 10);
+    // Retrieve the stored baseline date or default to today if not set.
+    final storedDate = prefs.getString('baselineDate') ?? today;
+    log('Stored date: $storedDate, Today: $today');
+
+    if (storedDate != today) {
+      // It's a new day: reset the baseline and daily steps.
+      prefs.setInt('baselineSteps', steps);
+      prefs.setString('baselineDate', today);
+      prefs.setInt('dailySteps', 0);
+      log('New day detected. Baseline reset to $steps for $today');
+    } else {
+      // Compute daily steps as the difference between current steps and the baseline.
+      final baseline = prefs.getInt('baselineSteps') ?? steps;
+      final dailySteps = steps - baseline;
+      prefs.setInt('dailySteps', dailySteps);
+      log('Daily steps updated: $dailySteps (Current: $steps, Baseline: $baseline)');
+    }
+
+    // Optionally, keep a separate record of the overall saved steps.
     prefs.setInt('savedSteps', steps);
   }
 


### PR DESCRIPTION
This pull request introduces several changes to the `steps_tracker` application, primarily focusing on background task management and step count persistence. The most important changes include the addition of a background task using Workmanager, improvements to step count persistence, and cleanup of unused code.

### Background Task Management:
* Added a background task using Workmanager to periodically update the daily step count. This task ensures that the step count is updated even when the app is not actively running. (`lib/main.dart`, [lib/main.dartL8-R57](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L8-R57))

### Step Count Persistence:
* Enhanced step count persistence by saving and retrieving the step count from `SharedPreferences`. This ensures that the step count is maintained across app restarts. (`lib/state/steps_tracker_cubit.dart`, [lib/state/steps_tracker_cubit.dartL7-R77](diffhunk://#diff-b1e1bc2445257af1fb607bca8f70f63b8c855ca1443221b484a79a90690e4ea5L7-R77))

### Code Cleanup:
* Removed the unused `_startBackgroundSync` method and associated callbackDispatcher function from `StepTrackerCubit`. These were replaced by the new Workmanager-based implementation. (`lib/state/steps_tracker_cubit.dart`, [lib/state/steps_tracker_cubit.dartL7-R77](diffhunk://#diff-b1e1bc2445257af1fb607bca8f70f63b8c855ca1443221b484a79a90690e4ea5L7-R77))

### UI Adjustments:
* Minor UI adjustments in the `main` function to ensure proper initialization and removal of redundant code. (`lib/main.dart`, [lib/main.dartL36-R79](diffhunk://#diff-e61eb31d013d12616f5532636a88cfa63631dda8f7829e5424e68542214d1608L36-R79))